### PR TITLE
feat: 블로그/썸네일 통합 API 구현 및 DB thumbnail_url 컬럼 추가

### DIFF
--- a/backend/api-server/README.md
+++ b/backend/api-server/README.md
@@ -274,35 +274,3 @@ curl -X POST "http://127.0.0.1:8000/api/policies/20250924005400211793/content?ty
 # 제목+요약+본문 일괄 생성
 curl -X POST "http://127.0.0.1:8000/api/policies/20250924005400211793/content?type=full"
 ```
-
-## Thumbnail Auto (LLM + S3 Upload)
-
-### 사용 예시
-```bash
-curl -X POST http://127.0.0.1:8000/api/thumbnails/auto \
-  -H "Content-Type: application/json" \
-  -d '{
-    "policy_id": "20250922005400211790",
-    "category": "복지",
-    "max_variants": 3
-  }'
-```
----
-
-💡 **설명**
-- 위 명령은 정책 ID(`policy_id`)를 기반으로 썸네일 자동 생성 API를 호출합니다.  
-- 백엔드가 DB에서 정책 정보를 조회하고,  
-  LLM(OpenAI API)을 이용해 문구를 생성한 후 이미지를 생성해 S3에 업로드합니다.  
-- 응답 예시는 다음과 같습니다 
-
-```json
-{
-  "ok": true,
-  "caption": "청년 복지,\n당신의 삶을 바꿀 기회!",
-  "result": {
-    "ok": true,
-    "storage": "s3",
-    "url": "https://youth-policy-thumbnails-kch.s3.ap-northeast-2.amazonaws.com/thumbnails/2025/11/20250922005400211790.png"
-  }
-}
-```

--- a/backend/api-server/main.py
+++ b/backend/api-server/main.py
@@ -71,7 +71,7 @@ async def health_check():
 from routes.policies import router as policies_router
 app.include_router(policies_router, prefix="/api")
 
-# 프롬프트 라우터 연결 (develop)
+# 프롬프트 라우터 연결
 from routes.prompts import router as prompts_router
 app.include_router(prompts_router, prefix="/api")
 
@@ -79,6 +79,10 @@ app.include_router(prompts_router, prefix="/api")
 from routes import thumbnails, thumbnails_auto
 app.include_router(thumbnails.router, prefix="/api")
 app.include_router(thumbnails_auto.router, prefix="/api")
+
+# 블로그 + 썸넬 라우터 연결
+from routes.blogs import router as blogs_router
+app.include_router(blogs_router, prefix="/api")
 
 
 # OpenAI Ping API

--- a/backend/api-server/routes/blogs.py
+++ b/backend/api-server/routes/blogs.py
@@ -1,0 +1,44 @@
+# routes/blogs.py
+import os, psycopg2, psycopg2.extras
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter(tags=["blogs"])
+
+def get_conn():
+    url = os.getenv("DB_URL") or os.getenv("DATABASE_URL")
+    if not url:
+        raise HTTPException(500, "DB_URL/DATABASE_URL not set")
+
+    # psycopg2는 'postgresql://...' 형식만 이해
+    url = url.replace("postgresql+psycopg2://", "postgresql://")
+
+    return psycopg2.connect(url, cursor_factory=psycopg2.extras.RealDictCursor)
+
+@router.get("/blogs")
+def list_blogs(limit: int = 12):
+    conn = get_conn(); cur = conn.cursor()
+    cur.execute("""
+        SELECT plcy_no, blog_title, blog_summary, category, region, thumbnail_url, updated_at
+        FROM blog_posts
+        WHERE generation_status = 'completed'
+        ORDER BY updated_at DESC
+        LIMIT %s
+    """, (limit,))
+    rows = cur.fetchall()
+    cur.close(); conn.close()
+    return {"items": rows, "count": len(rows)}
+
+@router.get("/blogs/{plcy_no}")
+def get_blog(plcy_no: str):
+    conn = get_conn(); cur = conn.cursor()
+    cur.execute("""
+        SELECT plcy_no, blog_title, blog_summary, blog_content,
+               category, region, thumbnail_url, updated_at
+        FROM blog_posts
+        WHERE plcy_no = %s
+    """, (plcy_no,))
+    row = cur.fetchone()
+    cur.close(); conn.close()
+    if not row:
+        raise HTTPException(404, "Blog post not found")
+    return row


### PR DESCRIPTION
요약
	•	blog_posts 테이블에 thumbnail_url 컬럼 추가
	•	정책 번호(plcy_no) 기준으로 S3 썸네일 URL 일괄 세팅
	•	블로그 조회 API 신규 추가 (routes/blogs.py)
	•	GET /api/blogs?limit=N : 최신 글 목록(썸네일/제목/요약)
	•	GET /api/blogs/{plcy_no} : 단일 글 상세(본문/썸네일/메타)

변경 사항
	•	routes/blogs.py 추가
	•	main.py : blogs 라우터 등록 (app.include_router(blogs_router, prefix="/api"))
	•	psycopg2 호환을 위해 postgresql+psycopg2:// → postgresql:// 보정 로직 포함

DB 마이그레이션
```
ALTER TABLE blog_posts ADD COLUMN IF NOT EXISTS thumbnail_url TEXT;

UPDATE blog_posts
SET thumbnail_url = 'https://youth-policy-thumbnails-kch.s3.ap-northeast-2.amazonaws.com/thumbnails/' || plcy_no || '.jpg'
WHERE thumbnail_url IS NULL;
```

실행/테스트
	/docs 진입
	•	List: GET /api/blogs?limit=5 → 200, items[*].thumbnail_url 확인
	•	Detail: GET /api/blogs/{plcy_no} → 200, blog_content/thumbnail_url 확인